### PR TITLE
Update Picker.tsx --updating close icon.

### DIFF
--- a/components/Picker/Picker.tsx
+++ b/components/Picker/Picker.tsx
@@ -176,7 +176,7 @@ const Picker: React.FC<Props> = ({
                   justifyContent: "center",
                 }}
               >
-                <Ionicons name="ios-close" size={20} color="#fff" />
+                <Ionicons name="close" size={20} color="#fff" />
               </TouchableOpacity>
             </View>
             <ScrollView showsVerticalScrollIndicator={false}>


### PR DESCRIPTION
Picker close icon is not visible. "ios-close" Icon from @expo/vector-icons is not available in latest version <=14.0.0